### PR TITLE
Metric name fix: ip_rx_packers_rate -> packets

### DIFF
--- a/metrics.json
+++ b/metrics.json
@@ -131,7 +131,7 @@
         ],
 
         "gauges": [
-            ["iprxpktsrate", "ip_rx_packers_rate"],
+            ["iprxpktsrate", "ip_rx_packets_rate"],
             ["iprxbytesrate", "ip_rx_bytes_rate"],
             ["iptxpktsrate", "ip_tx_packets_rate"],
             ["iptxbytesrate", "ip_bytes_rate"],


### PR DESCRIPTION
This fixes #11 